### PR TITLE
Replace equivalent fmt.Sprintf calls with strconv.Itoa

### DIFF
--- a/client/src/main/java/org/sourcegraph/client/Client.java
+++ b/client/src/main/java/org/sourcegraph/client/Client.java
@@ -7,7 +7,7 @@ public class Client {
     private final SourcegraphService service;
 
     public Client() {
-        this.service = new SourcegraphService();
+        this.service = new SourcegraphLookup();
     }
 
     public boolean isAuthorized() {


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls

[_Created by Sourcegraph batch change `malo/java-monorepo-upgrade-fix-callsites`._](https://demo.sourcegraph.com/users/malo/batch-changes/java-monorepo-upgrade-fix-callsites)