### PR TITLE
Replace equivalent fmt.Sprintf calls with strconv.Itoa

### DIFF
--- a/auth/src/main/java/org/sourcegraph/auth/Auth.java
+++ b/auth/src/main/java/org/sourcegraph/auth/Auth.java
@@ -1,10 +1,10 @@
 package org.sourcegraph.auth;
 
 import org.sourcegraph.Record;
-import org.sourcegraph.SourcegraphService;
+import org.sourcegraph.SourcegraphLookup;
 
 public class Auth {
-    private final SourcegraphService service;
+    private final SourcegraphLookup service;
 
     public Auth() {
         this.service = new SourcegraphLookup();

--- a/client/src/main/java/org/sourcegraph/client/Client.java
+++ b/client/src/main/java/org/sourcegraph/client/Client.java
@@ -1,10 +1,10 @@
 package org.sourcegraph.client;
 
 import org.sourcegraph.Record;
-import org.sourcegraph.SourcegraphService;
+import org.sourcegraph.SourcegraphLookup;
 
 public class Client {
-    private final SourcegraphService service;
+    private final SourcegraphLookup service;
 
     public Client() {
         this.service = new SourcegraphLookup();


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls

[_Created by Sourcegraph batch change `malo/update-fix-2`._](https://demo.sourcegraph.com/users/malo/batch-changes/update-fix-2)