### PR TITLE
Replace equivalent fmt.Sprintf calls with strconv.Itoa

### DIFF
--- a/auth/src/main/java/org/sourcegraph/auth/Auth.java
+++ b/auth/src/main/java/org/sourcegraph/auth/Auth.java
@@ -1,13 +1,13 @@
 package org.sourcegraph.auth;
 
 import org.sourcegraph.Record;
-import org.sourcegraph.SourcegraphService;
+import org.sourcegraph.SourcegraphLookup;
 
 public class Auth {
-    private final SourcegraphService service;
+    private final SourcegraphLookup service;
 
     public Auth() {
-        this.service = new SourcegraphService();
+        this.service = new SourcegraphLookup();
     }
 
     public boolean isAuthorized() {


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls

[_Created by Sourcegraph batch change `malo/update-fix-2`._](https://demo.sourcegraph.com/users/malo/batch-changes/update-fix-2)